### PR TITLE
Restrict event details to objects, validate email format

### DIFF
--- a/app/routes/events.py
+++ b/app/routes/events.py
@@ -66,8 +66,8 @@ def _validate_create_payload(payload):
     if "user_id" in payload and payload["user_id"] is not None and not isinstance(payload["user_id"], int):
         return "Field 'user_id' must be an integer"
 
-    if "details" in payload and payload["details"] is not None and not isinstance(payload["details"], (dict, list, str, int, float, bool)):
-        return "Field 'details' must be JSON-serializable"
+    if "details" in payload and payload["details"] is not None and not isinstance(payload["details"], dict):
+        return "Field 'details' must be a JSON object"
 
     return None
 

--- a/app/routes/users.py
+++ b/app/routes/users.py
@@ -41,6 +41,11 @@ def _validate_user_payload(payload, partial=False):
         if not value.strip():
             return field, f"Field '{field}' must not be empty"
 
+    if "email" in payload and isinstance(payload["email"], str):
+        email = payload["email"].strip()
+        if "@" not in email or "." not in email.split("@")[-1]:
+            return "email", "Field 'email' must be a valid email address"
+
     return None, None
 
 

--- a/tests/test_events_routes.py
+++ b/tests/test_events_routes.py
@@ -45,6 +45,16 @@ def test_list_events_returns_serialized_events(integration_client):
     ]
 
 
+def test_create_event_rejects_non_object_details(client):
+    response = client.post(
+        "/events",
+        json={"url_id": 1, "event_type": "click", "details": "just a string"},
+    )
+
+    assert response.status_code == 400
+    assert "details" in response.get_json()["error"].lower()
+
+
 def test_create_event_creates_row_and_returns_payload(integration_client):
     now = datetime(2026, 1, 1, 0, 0, 0)
     user = User.create(

--- a/tests/test_users_routes.py
+++ b/tests/test_users_routes.py
@@ -113,6 +113,16 @@ def test_update_user_updates_requested_fields(integration_client):
     }
 
 
+def test_create_user_rejects_invalid_email_format(integration_client):
+    response = integration_client.post(
+        "/users",
+        json={"username": "badactor", "email": "notanemail"},
+    )
+
+    assert response.status_code == 422
+    assert "email" in response.get_json()["errors"]
+
+
 def test_create_user_rejects_duplicate_email(integration_client):
     User.create(
         username="first",


### PR DESCRIPTION
- details field on POST /events now rejects non-dict values (strings, numbers, booleans) — a scroll must contain a full structure, not a word
- POST /users and PUT /users now reject emails missing @ or domain part